### PR TITLE
fix: update mysql version

### DIFF
--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.7
+FROM mysql:5.7-debian
 
 RUN apt-get update -y && \
     apt-get install -y locales && \


### PR DESCRIPTION
update mysql version

cannot build this error messages

```cmd
 => ERROR [docker-fastapi-mysql-app-mysql 2/6] RUN apt-get update -y &&     apt-get install -y locales &&     rm -rf   1.8s
------
 > [docker-fastapi-mysql-app-mysql 2/6] RUN apt-get update -y &&     apt-get install -y locales &&     rm -rf /var/lib/apt/lists/* &&     echo "ja_JP.UTF-8 UTF-8" > /etc/locale.gen &&     locale-gen ja_JP.UTF-8:
#0 0.560 /bin/sh: apt-get: command not found
------
failed to solve: executor failed running [/bin/sh -c apt-get update -y &&     apt-get install -y locales &&     rm -rf /var/lib/apt/lists/* &&     echo "ja_JP.UTF-8 UTF-8" > /etc/locale.gen &&     locale-gen ja_JP.UTF-8]: exit code: 127
```

source here
https://stackoverflow.com/questions/72946649/dockerfile-running-from-mysql-cannot-access-apt-get

https://hub.docker.com/_/mysql
