### PR TITLE
roleを確認する関数

### DIFF
--- a/app/models/auth.py
+++ b/app/models/auth.py
@@ -38,6 +38,17 @@ class AuthModel(AbstractModel):
         sql = "INSERT INTO users(username, password) VALUE (%s, %s);"
         self.execute(sql, username, hashed_password)
 
+    def create_user_with_role(self, username, password, role):
+        """
+        新規ユーザ作成
+        :param username: ユーザ名
+        :param password: パスワード
+        :return:
+        """
+        hashed_password = self.hash_password(password)
+        sql = "INSERT INTO users(username, password, role) VALUE (%s, %s, %s);"
+        self.execute(sql, username, hashed_password, role)
+
     def find_user_by_name_and_password(self, username, password):
         """
         ユーザ名とパスワードからユーザを探す

--- a/app/utilities/check_role.py
+++ b/app/utilities/check_role.py
@@ -1,0 +1,39 @@
+import typing as t
+import logging
+
+
+def check_role(
+    user,
+    with_role: str = None,
+    with_roles: t.List[str] = None,
+):
+    """
+    ユーザのロールを確認する
+    :param user: ユーザの辞書
+    :param with_role: 一致するロール
+    :param with_roles: 一致するロールのリスト
+    :return: ロールが一致したらTrue, 一致しなければFalse
+
+    example:
+    @app.get("/admin")
+    @check_login
+    def admin_index(request: Request, session_id=Cookie(default=None)):
+        user = session.get(session_id).get("user")
+        if not check_role(user, with_role="admin"):
+            return RedirectResponse("/")
+        return templates.TemplateResponse("admin.html", {"request": request, "user": user})
+    """
+    if with_role is None and with_roles is None:
+        raise TypeError("with_role or with_roles is required")
+    if with_role is not None and with_roles is not None:
+        raise TypeError("with_role and with_roles cannot be used together")
+
+    role = user.get("role")
+    if not role:
+        logging.warning(f"Role is {role}, is seems a None-like value")
+
+    if with_role is not None:
+        return role == with_role
+
+    if with_roles is not None:
+        return role in with_roles

--- a/docker/mysql/sqls/initdb.d/create_db.sql
+++ b/docker/mysql/sqls/initdb.d/create_db.sql
@@ -4,7 +4,8 @@ CREATE TABLE IF NOT EXISTS users
     id         int(12) primary key auto_increment,
     username   varchar(100) not null,
     password   varchar(100) not null,
-    created_at datetime     not null default CURRENT_TIMESTAMP
+    created_at datetime     not null default CURRENT_TIMESTAMP,
+    role       varchar(100) not null default 'user'
 ) CHARACTER SET UTF8
   COLLATE utf8_general_ci;
 


### PR DESCRIPTION
認可の機能を僕が考える一番シンプルな方法で実装しました。
- userテーブルに`role`のカラムの追加
- sessionから取得するuserのroleを確認する関数の作成
- [roleを指定するユーザ作成のメソッド](https://github.com/KuroiCc/docker-fastapi-mysql-app/commit/058aeb042f5842db0d1d8d7bc2105403cd7120bd)

使い方はこんな感じ
```python

from app.utilities.check_role import check_role

...

@app.get("/admin")
@check_login
def admin_index(request: Request, session_id=Cookie(default=None)):
    user = session.get(session_id).get("user")
    if not check_role(user, with_role="admin"):
        return RedirectResponse("/")
    return templates.TemplateResponse("admin.html", {"request": request, "user": user})
```